### PR TITLE
Change when shipping information is logged

### DIFF
--- a/controllers/OneShipStation_OrdersController.php
+++ b/controllers/OneShipStation_OrdersController.php
@@ -161,13 +161,12 @@ class Oneshipstation_OrdersController extends BaseController
 
         $order->orderStatusId = $status->id;
         $order->message = $this->orderStatusMessageFromShipstationParams();
-
+        $shippingInformation = $this->getShippingInformationFromParams();
+        if (!craft()->oneShipStation_shippingLog->logShippingInformation($order, $shippingInformation)) {
+            throw new ErrorException('Logging shipping information failed for order ' . $order->id);
+        }
+        
         if (craft()->commerce_orders->saveOrder($order)) {
-            $shippingInformation = $this->getShippingInformationFromParams();
-            if (!craft()->oneShipStation_shippingLog->logShippingInformation($order, $shippingInformation)) {
-                throw new ErrorException('Logging shipping information failed for order ' . $order->id);
-            }
-
             $this->returnJson(['success' => true]); //TODO return 200 success
         } else {
             throw new ErrorException('Failed to save order with id ' . $order->id);


### PR DESCRIPTION
Logging the shipping information before the order is saved allows the tracking info to be used by emails triggered when the order status change is saved.